### PR TITLE
Fix https://github.com/neayi/tripleperformance/issues/417

### DIFF
--- a/includes/Target.php
+++ b/includes/Target.php
@@ -159,7 +159,7 @@ class Target {
 	 * @return String regular expression pattern
 	 */
 	private function buildRegex( $searchTerm ) {
-		return '/(?<![\:\.\@\/\?\&])' . $this->wordStart . $searchTerm . $this->wordEnd . '/S';
+		return '/(?<![\:\.\@\/\?\&])' . $this->wordStart . $searchTerm . $this->wordEnd . '/Su';
 	}
 
 	/**


### PR DESCRIPTION
Makes LinkTitles matching targets and source by dealing with UTF8 encoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced regex functionality to support Unicode characters, improving text processing capabilities.
  
- **Bug Fixes**
	- Corrected word boundary handling in regex, ensuring accurate matching for diverse character sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->